### PR TITLE
Visual calibration of the table height

### DIFF
--- a/app/scripts/r1-grasping.xml
+++ b/app/scripts/r1-grasping.xml
@@ -358,6 +358,11 @@
                 <protocol>fast_tcp</protocol>
         </connection>
         <connection>
+                <from>/action-gateway/depth/rpc</from>
+                <to>/depthCamera/rpc:i</to>
+                <protocol>fast_tcp</protocol>
+        </connection>
+        <connection>
                 <from>/iolHelper/opc</from>
                 <to>/memory/rpc</to>
                 <protocol>fast_tcp</protocol>

--- a/modules/action-gateway/app/conf/config-sim.ini
+++ b/modules/action-gateway/app/conf/config-sim.ini
@@ -2,7 +2,6 @@
 robot               SIM_CER_ROBOT
 period              0.1             // [s]
 speed_hand          30.0            // [deg/s]
-table_height        0.7             // [m]
 
 [home]
 head                (30.0 0.0)      // [deg]
@@ -21,3 +20,10 @@ lower_arm_heave     0.03            // [m]
 left_hand           (70.0 70.0)     // [deg]
 right_hand          (70.0 70.0)     // [deg]
 lift                0.15            // [m]
+
+[table]
+default_height      0.7             // [m]
+num_pixels          100
+pixels_bounds       (20 120 300 220)
+ransac_threshold    0.01            // [m]
+

--- a/modules/action-gateway/app/conf/config.ini
+++ b/modules/action-gateway/app/conf/config.ini
@@ -2,7 +2,6 @@
 robot               cer
 period              0.1             // [s]
 speed_hand          30.0            // [deg/s]
-table_height        0.7             // [m]
 
 [home]
 head                (30.0 0.0)      // [deg]
@@ -21,3 +20,9 @@ lower_arm_heave     0.03            // [m]
 left_hand           (70.0 70.0)     // [deg]
 right_hand          (70.0 70.0)     // [deg]
 lift                0.15            // [m]
+
+[table]
+default_height      0.7             // [m]
+num_pixels          100
+pixels_bounds       (20 120 300 220)
+ransac_threshold    0.01            // [m]


### PR DESCRIPTION
This PR provides `action-gateway` with the capability of visually calibrating the table height.

The calibration is performed by means of [**RANSAC**][1] so that the height is retrieved robustly using the depth sensor in the presence of outliers represented by a few objects lying on the table. As long as the objects cover an area less wide than the table surface the robot can see, the algorithm should be able to find the correct value.

The routine implementing the RANSAC is very simple:
https://github.com/robotology/r1-grasping/blob/4f831af378c59b823f3f5c1503c3b340fb49d4fa/modules/action-gateway/src/main.cpp#L820-L842

A configuration parameter can be used as fallback in case the RANSAC fails:
https://github.com/robotology/r1-grasping/blob/4f831af378c59b823f3f5c1503c3b340fb49d4fa/modules/action-gateway/app/conf/config.ini#L25 
or the following new connection is not in place:
https://github.com/robotology/r1-grasping/blob/4f831af378c59b823f3f5c1503c3b340fb49d4fa/app/scripts/r1-grasping.xml#L360-L364 

[1]: https://en.wikipedia.org/wiki/Random_sample_consensus